### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can do the same with your songs.
 Detailed Profile settings also offered where you can set bitrate, framerate, size and format as needed. 
 FFMPEG engine is used at the core to perform my functions.
 
-##Deprecated##
+## Deprecated ##
 This project is not developed any more since 2013. You are welcome to use the FFMPEG conversion code and sound waves display code. If you need to use/update some other code too, you are welcome.
 
 My first android project, so any forking is good. You are welcome to use/edit the project.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
